### PR TITLE
Correction crash + nettoyage

### DIFF
--- a/Habilitations/dal/AccesDonnees.cs
+++ b/Habilitations/dal/AccesDonnees.cs
@@ -8,12 +8,12 @@ namespace Habilitations.dal
     /// <summary>
     /// Classe permettant de gérer les demandes concernant les données distantes
     /// </summary>
-    public class AccesDonnees
+    public static class AccesDonnees
     {
         /// <summary>
         /// chaine de connexion à la bdd
         /// </summary>
-        private static string connectionString = "server=localhost;user id=habilitations;password=motdepasseuser;database=habilitations;SslMode=none";
+        readonly private static string connectionString = "server=localhost;user id=habilitations;password=motdepasseuser;database=habilitations;SslMode=none";
 
         /// <summary>
         /// Controle si l'utillisateur a le droit de se connecter (nom, prénom, pwd est profil "admin")
@@ -26,10 +26,11 @@ namespace Habilitations.dal
         {
             string req = "select * from developpeur d join profil p on d.idprofil=p.idprofil ";
             req += "where d.nom=@nom and d.prenom=@prenom and pwd=SHA2(@pwd, 256) and p.nom='admin';";
-            Dictionary<string, object> parameters = new Dictionary<string, object>();
-            parameters.Add("@nom", nom);
-            parameters.Add("@prenom", prenom);
-            parameters.Add("@pwd", pwd);
+            Dictionary<string, object> parameters = new Dictionary<string, object>
+            {   {"@nom", nom },
+                {"@prenom", prenom },
+                {"@pwd", pwd }
+            };
             ConnexionBDD curs = ConnexionBDD.GetInstance(connectionString);
             curs.ReqSelect(req, parameters);
             if (curs.Read())
@@ -91,8 +92,7 @@ namespace Habilitations.dal
         public static void DelDepveloppeur(Developpeur developpeur)
         {
             string req = "delete from developpeur where iddeveloppeur = @iddeveloppeur;";
-            Dictionary<string, object> parameters = new Dictionary<string, object>();
-            parameters.Add("@iddeveloppeur", developpeur.Iddeveloppeur);
+            Dictionary<string, object> parameters = new Dictionary<string, object> { { "@iddeveloppeur", developpeur.Iddeveloppeur } };
             ConnexionBDD conn = ConnexionBDD.GetInstance(connectionString);
             conn.ReqUpdate(req, parameters);
         }
@@ -105,13 +105,14 @@ namespace Habilitations.dal
         {
             string req = "insert into developpeur(nom, prenom, tel, mail, pwd, idprofil) ";
             req += "values (@nom, @prenom, @tel, @mail, @pwd, @idprofil);";
-            Dictionary<string, object> parameters = new Dictionary<string, object>();
-            parameters.Add("@nom", developpeur.Nom);
-            parameters.Add("@prenom", developpeur.Prenom);
-            parameters.Add("@tel", developpeur.Tel);
-            parameters.Add("@mail", developpeur.Mail);
-            parameters.Add("@pwd", GetStringSha256Hash(developpeur.Nom));
-            parameters.Add("@idprofil", developpeur.Idprofil);
+            Dictionary<string, object> parameters = new Dictionary<string, object>
+            { {"@nom", developpeur.Nom},
+            {"@prenom", developpeur.Prenom},
+            {"@tel", developpeur.Tel},
+            {"@mail", developpeur.Mail},
+            {"@pwd", GetStringSha256Hash(developpeur.Nom)},
+            {"@idprofil", developpeur.Idprofil},
+            };
             ConnexionBDD conn = ConnexionBDD.GetInstance(connectionString);
             conn.ReqUpdate(req, parameters);
         }
@@ -124,13 +125,15 @@ namespace Habilitations.dal
         {
             string req = "update developpeur set nom = @nom, prenom = @prenom, tel = @tel, mail = @mail, idprofil = @idprofil ";
             req += "where iddeveloppeur = @iddeveloppeur;";
-            Dictionary<string, object> parameters = new Dictionary<string, object>();
-            parameters.Add("@idDeveloppeur", developpeur.Iddeveloppeur);
-            parameters.Add("@nom", developpeur.Nom);
-            parameters.Add("@prenom", developpeur.Prenom);
-            parameters.Add("@tel", developpeur.Tel);
-            parameters.Add("@mail", developpeur.Mail);
-            parameters.Add("idprofil", developpeur.Idprofil);
+            Dictionary<string, object> parameters = new Dictionary<string, object>
+            {
+                {"@idDeveloppeur", developpeur.Iddeveloppeur },
+                {"@nom", developpeur.Nom },
+                {"@prenom", developpeur.Prenom },
+                {"@tel", developpeur.Tel },
+                {"@mail", developpeur.Mail },
+                {"idprofil", developpeur.Idprofil },
+            };
             ConnexionBDD conn = ConnexionBDD.GetInstance(connectionString);
             conn.ReqUpdate(req, parameters);
         }
@@ -143,9 +146,10 @@ namespace Habilitations.dal
         {
             string req = "update developpeur set pwd = @pwd ";
             req += "where iddeveloppeur = @iddeveloppeur;";
-            Dictionary<string, object> parameters = new Dictionary<string, object>();
-            parameters.Add("@idDeveloppeur", developpeur.Iddeveloppeur);
-            parameters.Add("@pwd", GetStringSha256Hash(developpeur.Pwd));
+            Dictionary<string, object> parameters = new Dictionary<string, object> {
+                {"@idDeveloppeur", developpeur.Iddeveloppeur },
+                {"@pwd", GetStringSha256Hash(developpeur.Pwd) }
+            };
             ConnexionBDD conn = ConnexionBDD.GetInstance(connectionString);
             conn.ReqUpdate(req, parameters);
         }

--- a/Habilitations/vue/frmHabilitations.Designer.cs
+++ b/Habilitations/vue/frmHabilitations.Designer.cs
@@ -64,12 +64,14 @@
             this.dgvDeveloppeurs.AllowUserToAddRows = false;
             this.dgvDeveloppeurs.AllowUserToDeleteRows = false;
             this.dgvDeveloppeurs.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dgvDeveloppeurs.Location = new System.Drawing.Point(6, 19);
+            this.dgvDeveloppeurs.Location = new System.Drawing.Point(8, 23);
+            this.dgvDeveloppeurs.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.dgvDeveloppeurs.MultiSelect = false;
             this.dgvDeveloppeurs.Name = "dgvDeveloppeurs";
             this.dgvDeveloppeurs.ReadOnly = true;
             this.dgvDeveloppeurs.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.AutoSizeToAllHeaders;
-            this.dgvDeveloppeurs.Size = new System.Drawing.Size(581, 206);
+            this.dgvDeveloppeurs.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.dgvDeveloppeurs.Size = new System.Drawing.Size(775, 254);
             this.dgvDeveloppeurs.TabIndex = 0;
             // 
             // grbLesDeveloppeurs
@@ -78,18 +80,21 @@
             this.grbLesDeveloppeurs.Controls.Add(this.btnSupprimer);
             this.grbLesDeveloppeurs.Controls.Add(this.btnModifier);
             this.grbLesDeveloppeurs.Controls.Add(this.dgvDeveloppeurs);
-            this.grbLesDeveloppeurs.Location = new System.Drawing.Point(12, 12);
+            this.grbLesDeveloppeurs.Location = new System.Drawing.Point(16, 15);
+            this.grbLesDeveloppeurs.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.grbLesDeveloppeurs.Name = "grbLesDeveloppeurs";
-            this.grbLesDeveloppeurs.Size = new System.Drawing.Size(605, 264);
+            this.grbLesDeveloppeurs.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.grbLesDeveloppeurs.Size = new System.Drawing.Size(807, 325);
             this.grbLesDeveloppeurs.TabIndex = 1;
             this.grbLesDeveloppeurs.TabStop = false;
             this.grbLesDeveloppeurs.Text = "les développeurs";
             // 
             // btnChangPwd
             // 
-            this.btnChangPwd.Location = new System.Drawing.Point(168, 231);
+            this.btnChangPwd.Location = new System.Drawing.Point(224, 284);
+            this.btnChangPwd.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnChangPwd.Name = "btnChangPwd";
-            this.btnChangPwd.Size = new System.Drawing.Size(85, 23);
+            this.btnChangPwd.Size = new System.Drawing.Size(113, 28);
             this.btnChangPwd.TabIndex = 3;
             this.btnChangPwd.Text = "changer pwd";
             this.btnChangPwd.UseVisualStyleBackColor = true;
@@ -97,9 +102,10 @@
             // 
             // btnSupprimer
             // 
-            this.btnSupprimer.Location = new System.Drawing.Point(87, 231);
+            this.btnSupprimer.Location = new System.Drawing.Point(116, 284);
+            this.btnSupprimer.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnSupprimer.Name = "btnSupprimer";
-            this.btnSupprimer.Size = new System.Drawing.Size(75, 23);
+            this.btnSupprimer.Size = new System.Drawing.Size(100, 28);
             this.btnSupprimer.TabIndex = 2;
             this.btnSupprimer.Text = "supprimer";
             this.btnSupprimer.UseVisualStyleBackColor = true;
@@ -107,9 +113,10 @@
             // 
             // btnModifier
             // 
-            this.btnModifier.Location = new System.Drawing.Point(6, 231);
+            this.btnModifier.Location = new System.Drawing.Point(8, 284);
+            this.btnModifier.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnModifier.Name = "btnModifier";
-            this.btnModifier.Size = new System.Drawing.Size(75, 23);
+            this.btnModifier.Size = new System.Drawing.Size(100, 28);
             this.btnModifier.TabIndex = 1;
             this.btnModifier.Text = "modifier";
             this.btnModifier.UseVisualStyleBackColor = true;
@@ -129,18 +136,21 @@
             this.grbDeveloppeur.Controls.Add(this.txtPrenom);
             this.grbDeveloppeur.Controls.Add(this.label1);
             this.grbDeveloppeur.Controls.Add(this.txtNom);
-            this.grbDeveloppeur.Location = new System.Drawing.Point(12, 282);
+            this.grbDeveloppeur.Location = new System.Drawing.Point(16, 347);
+            this.grbDeveloppeur.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.grbDeveloppeur.Name = "grbDeveloppeur";
-            this.grbDeveloppeur.Size = new System.Drawing.Size(605, 129);
+            this.grbDeveloppeur.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.grbDeveloppeur.Size = new System.Drawing.Size(807, 159);
             this.grbDeveloppeur.TabIndex = 2;
             this.grbDeveloppeur.TabStop = false;
             this.grbDeveloppeur.Text = "ajouter un développeur";
             // 
             // btnAnnulerDeveloppeur
             // 
-            this.btnAnnulerDeveloppeur.Location = new System.Drawing.Point(87, 98);
+            this.btnAnnulerDeveloppeur.Location = new System.Drawing.Point(116, 121);
+            this.btnAnnulerDeveloppeur.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnAnnulerDeveloppeur.Name = "btnAnnulerDeveloppeur";
-            this.btnAnnulerDeveloppeur.Size = new System.Drawing.Size(75, 23);
+            this.btnAnnulerDeveloppeur.Size = new System.Drawing.Size(100, 28);
             this.btnAnnulerDeveloppeur.TabIndex = 10;
             this.btnAnnulerDeveloppeur.Text = "annuler";
             this.btnAnnulerDeveloppeur.UseVisualStyleBackColor = true;
@@ -148,9 +158,10 @@
             // 
             // btnEnregDeveloppeur
             // 
-            this.btnEnregDeveloppeur.Location = new System.Drawing.Point(6, 98);
+            this.btnEnregDeveloppeur.Location = new System.Drawing.Point(8, 121);
+            this.btnEnregDeveloppeur.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnEnregDeveloppeur.Name = "btnEnregDeveloppeur";
-            this.btnEnregDeveloppeur.Size = new System.Drawing.Size(75, 23);
+            this.btnEnregDeveloppeur.Size = new System.Drawing.Size(100, 28);
             this.btnEnregDeveloppeur.TabIndex = 9;
             this.btnEnregDeveloppeur.Text = "enregistrer";
             this.btnEnregDeveloppeur.UseVisualStyleBackColor = true;
@@ -159,86 +170,96 @@
             // cboProfil
             // 
             this.cboProfil.FormattingEnabled = true;
-            this.cboProfil.Location = new System.Drawing.Point(354, 71);
+            this.cboProfil.Location = new System.Drawing.Point(472, 87);
+            this.cboProfil.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.cboProfil.Name = "cboProfil";
-            this.cboProfil.Size = new System.Drawing.Size(161, 21);
+            this.cboProfil.Size = new System.Drawing.Size(213, 24);
             this.cboProfil.TabIndex = 8;
             // 
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(308, 74);
+            this.label5.Location = new System.Drawing.Point(411, 91);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(29, 13);
+            this.label5.Size = new System.Drawing.Size(39, 17);
             this.label5.TabIndex = 8;
             this.label5.Text = "profil";
             // 
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(308, 22);
+            this.label4.Location = new System.Drawing.Point(411, 27);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(25, 13);
+            this.label4.Size = new System.Drawing.Size(33, 17);
             this.label4.TabIndex = 7;
             this.label4.Text = "mail";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(308, 48);
+            this.label3.Location = new System.Drawing.Point(411, 59);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(18, 13);
+            this.label3.Size = new System.Drawing.Size(23, 17);
             this.label3.TabIndex = 6;
             this.label3.Text = "tel";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(6, 48);
+            this.label2.Location = new System.Drawing.Point(8, 59);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(42, 13);
+            this.label2.Size = new System.Drawing.Size(56, 17);
             this.label2.TabIndex = 5;
             this.label2.Text = "prenom";
             // 
             // txtMail
             // 
-            this.txtMail.Location = new System.Drawing.Point(354, 19);
+            this.txtMail.Location = new System.Drawing.Point(472, 23);
+            this.txtMail.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtMail.MaxLength = 50;
             this.txtMail.Name = "txtMail";
-            this.txtMail.Size = new System.Drawing.Size(245, 20);
+            this.txtMail.Size = new System.Drawing.Size(325, 22);
             this.txtMail.TabIndex = 6;
             // 
             // txtTel
             // 
-            this.txtTel.Location = new System.Drawing.Point(354, 45);
+            this.txtTel.Location = new System.Drawing.Point(472, 55);
+            this.txtTel.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtTel.MaxLength = 15;
             this.txtTel.Name = "txtTel";
-            this.txtTel.Size = new System.Drawing.Size(161, 20);
+            this.txtTel.Size = new System.Drawing.Size(213, 22);
             this.txtTel.TabIndex = 7;
             // 
             // txtPrenom
             // 
-            this.txtPrenom.Location = new System.Drawing.Point(54, 45);
+            this.txtPrenom.Location = new System.Drawing.Point(72, 55);
+            this.txtPrenom.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtPrenom.MaxLength = 20;
             this.txtPrenom.Name = "txtPrenom";
-            this.txtPrenom.Size = new System.Drawing.Size(245, 20);
+            this.txtPrenom.Size = new System.Drawing.Size(325, 22);
             this.txtPrenom.TabIndex = 4;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(6, 22);
+            this.label1.Location = new System.Drawing.Point(8, 27);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(27, 13);
+            this.label1.Size = new System.Drawing.Size(35, 17);
             this.label1.TabIndex = 1;
             this.label1.Text = "nom";
             // 
             // txtNom
             // 
-            this.txtNom.Location = new System.Drawing.Point(54, 19);
+            this.txtNom.Location = new System.Drawing.Point(72, 23);
+            this.txtNom.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtNom.MaxLength = 20;
             this.txtNom.Name = "txtNom";
-            this.txtNom.Size = new System.Drawing.Size(245, 20);
+            this.txtNom.Size = new System.Drawing.Size(325, 22);
             this.txtNom.TabIndex = 3;
             // 
             // grbPwd
@@ -249,9 +270,11 @@
             this.grbPwd.Controls.Add(this.txtPwd2);
             this.grbPwd.Controls.Add(this.txtPwd1);
             this.grbPwd.Controls.Add(this.label6);
-            this.grbPwd.Location = new System.Drawing.Point(12, 417);
+            this.grbPwd.Location = new System.Drawing.Point(16, 513);
+            this.grbPwd.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.grbPwd.Name = "grbPwd";
-            this.grbPwd.Size = new System.Drawing.Size(605, 77);
+            this.grbPwd.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.grbPwd.Size = new System.Drawing.Size(807, 95);
             this.grbPwd.TabIndex = 3;
             this.grbPwd.TabStop = false;
             this.grbPwd.Text = "changer le mot de passe";
@@ -259,17 +282,19 @@
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(308, 22);
+            this.label7.Location = new System.Drawing.Point(411, 27);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(40, 13);
+            this.label7.Size = new System.Drawing.Size(52, 17);
             this.label7.TabIndex = 5;
             this.label7.Text = "encore";
             // 
             // btnAnnulerPwd
             // 
-            this.btnAnnulerPwd.Location = new System.Drawing.Point(87, 45);
+            this.btnAnnulerPwd.Location = new System.Drawing.Point(116, 55);
+            this.btnAnnulerPwd.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnAnnulerPwd.Name = "btnAnnulerPwd";
-            this.btnAnnulerPwd.Size = new System.Drawing.Size(75, 23);
+            this.btnAnnulerPwd.Size = new System.Drawing.Size(100, 28);
             this.btnAnnulerPwd.TabIndex = 4;
             this.btnAnnulerPwd.Text = "annuler";
             this.btnAnnulerPwd.UseVisualStyleBackColor = true;
@@ -277,9 +302,10 @@
             // 
             // btnEnregPwd
             // 
-            this.btnEnregPwd.Location = new System.Drawing.Point(6, 45);
+            this.btnEnregPwd.Location = new System.Drawing.Point(8, 55);
+            this.btnEnregPwd.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnEnregPwd.Name = "btnEnregPwd";
-            this.btnEnregPwd.Size = new System.Drawing.Size(75, 23);
+            this.btnEnregPwd.Size = new System.Drawing.Size(100, 28);
             this.btnEnregPwd.TabIndex = 3;
             this.btnEnregPwd.Text = "Enregistrer";
             this.btnEnregPwd.UseVisualStyleBackColor = true;
@@ -287,39 +313,43 @@
             // 
             // txtPwd2
             // 
-            this.txtPwd2.Location = new System.Drawing.Point(354, 19);
+            this.txtPwd2.Location = new System.Drawing.Point(472, 23);
+            this.txtPwd2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtPwd2.MaxLength = 50;
             this.txtPwd2.Name = "txtPwd2";
             this.txtPwd2.PasswordChar = '*';
-            this.txtPwd2.Size = new System.Drawing.Size(245, 20);
+            this.txtPwd2.Size = new System.Drawing.Size(325, 22);
             this.txtPwd2.TabIndex = 2;
             // 
             // txtPwd1
             // 
-            this.txtPwd1.Location = new System.Drawing.Point(54, 19);
+            this.txtPwd1.Location = new System.Drawing.Point(72, 23);
+            this.txtPwd1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtPwd1.MaxLength = 50;
             this.txtPwd1.Name = "txtPwd1";
             this.txtPwd1.PasswordChar = '*';
-            this.txtPwd1.Size = new System.Drawing.Size(245, 20);
+            this.txtPwd1.Size = new System.Drawing.Size(325, 22);
             this.txtPwd1.TabIndex = 1;
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(6, 22);
+            this.label6.Location = new System.Drawing.Point(8, 27);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(27, 13);
+            this.label6.Size = new System.Drawing.Size(33, 17);
             this.label6.TabIndex = 0;
             this.label6.Text = "pwd";
             // 
             // FrmHabilitations
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(627, 502);
+            this.ClientSize = new System.Drawing.Size(836, 618);
             this.Controls.Add(this.grbPwd);
             this.Controls.Add(this.grbDeveloppeur);
             this.Controls.Add(this.grbLesDeveloppeurs);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "FrmHabilitations";
             this.Text = "Habilitations";
             ((System.ComponentModel.ISupportInitialize)(this.dgvDeveloppeurs)).EndInit();

--- a/Habilitations/vue/frmHabilitations.cs
+++ b/Habilitations/vue/frmHabilitations.cs
@@ -14,7 +14,7 @@ namespace Habilitations.vue
         /// <summary>
         /// instance du controleur
         /// </summary>
-        private Controle controle;
+        readonly private Controle controle;
         /// <summary>
         /// Booléen pour savoir si une modification est demandée
         /// </summary>
@@ -22,11 +22,11 @@ namespace Habilitations.vue
         /// <summary>
         /// Objet pour gérer la liste des développeurs
         /// </summary>
-        BindingSource bdgDeveloppeurs = new BindingSource();
+        readonly BindingSource bdgDeveloppeurs = new BindingSource();
         /// <summary>
         /// Objet pour gérer la liste des profils
         /// </summary>
-        BindingSource bdgProfils = new BindingSource();
+        readonly BindingSource bdgProfils = new BindingSource();
 
         /// <summary>
         /// Initialisation des composants graphiques


### PR DESCRIPTION
+ Correction du bug faisant crasher l'application lors d'un clic sur le bouton suppression. Le bug survenait si une cellule était sélectionnée et non une ligne : 
J'ai changé la propriété SelectionMode du DataGridView en "FullRowSelect", pour ne pouvoir sélectionner qu'une ligne entière.

+ Nettoyage du code (readonly sur les variables appropriées, et optimisation de l'initialisation des dictionnaires)